### PR TITLE
Improve claim text cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ python claim_irregularity_finder.py
 The script will:
 
 1. Fetch unread Gmail messages containing "State Farm Claim".
-2. Download any attachments to the `evidence` directory and extract text from PDFs or text files.
+2. Download any attachments to the `evidence` directory and extract text from PDFs or text files.  Common headers, page numbers, and line-item table rows are removed during preprocessing.
 3. Parse events from the collected text and build a directed graph with NetworkX.
 4. Send the list of events to the OpenAI API to detect irregular patterns.
 5. Annotate the graph with the irregularity results, print a summary table, and produce `claim_irregularity_map.html` and `claim_graph.graphml`.

--- a/claim_irregularity_finder.py
+++ b/claim_irregularity_finder.py
@@ -122,10 +122,13 @@ def _extract_eml_text(path: str) -> str:
 def _clean_text(text: str) -> str:
     """Remove common header/footer patterns from extracted text."""
     cleaned_lines = []
+    item_pat = re.compile(r"^\s*(?:\d+/\d+/\d+|\d+)\s+E\d{2}\b")
     for line in text.splitlines():
         if re.search(r"^\s*Page\s+\d+", line):
             continue
         if re.search(r"GOLD COAST AUTO BODY INC", line, re.I):
+            continue
+        if item_pat.search(line):
             continue
         cleaned_lines.append(line)
     return "\n".join(cleaned_lines)


### PR DESCRIPTION
## Summary
- filter line-item rows when cleaning PDF text
- mention cleaning step in README

## Testing
- `python -m py_compile claim_irregularity_finder.py`