### PR TITLE
Improve parse_events newline handling

### DIFF
--- a/claim_irregularity_finder.py
+++ b/claim_irregularity_finder.py
@@ -203,23 +203,23 @@ def parse_events(texts: List[str]) -> List[Dict]:
         r"(?P<timestamp>(?:\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{4})"
         r"[ T]\d{1,2}:\d{2}(?::\d{2})?(?:\s?[APap][Mm])?)"
     )
-    next_ts = r"(?=\n(?:\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{4})[ T]\d{1,2}:\d{2}|\n?$)"
+    next_ts = r"(?=(?:\r?\n)+(?:\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{4})[ T]\d{1,2}:\d{2}|\Z)"
     patterns = [
         re.compile(
             ts_part
-            + r"\s*(?P<actor>[^:]+):\s*(?P<action>[^.\n]+)\.?\s*(?P<details>.*?)"
+            + r"[ \t]*(?P<actor>[^:]+):[ \t]*(?P<action>[^.\n]+)\.?[ \t]*(?P<details>.*?)"
             + next_ts,
             re.DOTALL,
         ),
         re.compile(
             ts_part
-            + r"\s*-\s*(?P<actor>[^-]+)\s*-\s*(?P<action>[^-\n]+)\s*-\s*(?P<details>.*?)"
+            + r"[ \t]*-[ \t]*(?P<actor>[^-]+)[ \t]*-[ \t]*(?P<action>[^-\n]+)[ \t]*-[ \t]*(?P<details>.*?)"
             + next_ts,
             re.DOTALL,
         ),
         re.compile(
             ts_part
-            + r"\s+(?P<actor>[^-:\n]+)\s+(?P<action>[^-:\n]+)\s*(?P<details>.*?)"
+            + r"[ \t]+(?P<actor>[^-:\n]+)[ \t]+(?P<action>[^-:\n]+)[ \t]*(?P<details>.*?)"
             + next_ts,
             re.DOTALL,
         ),

--- a/tests/test_parse_events.py
+++ b/tests/test_parse_events.py
@@ -1,0 +1,57 @@
+import ast
+import textwrap
+import types
+
+
+def load_parse_events():
+    with open("claim_irregularity_finder.py", "r", encoding="utf-8") as f:
+        source = f.read()
+    module = ast.parse(source)
+    code_sections = []
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name in (
+            "parse_events",
+            "_clean_text",
+            "_normalize_timestamp",
+        ):
+            code_sections.append(
+                textwrap.dedent("".join(source.splitlines(True)[node.lineno - 1 : node.end_lineno]))
+            )
+    namespace = {}
+    exec(
+        "import re\nfrom typing import List, Dict\nfrom datetime import datetime\n"
+        "def tqdm(x, **k):\n    return x\n" + "\n".join(code_sections),
+        namespace,
+    )
+    return namespace["parse_events"]
+
+
+parse_events = load_parse_events()
+import unittest
+
+
+class ParseEventsTest(unittest.TestCase):
+    def test_blank_lines(self):
+        text = (
+            "2024-06-15 14:10 Actor1: Did something\n\n"
+            "2024-06-16 09:00 Actor2: Did another"
+        )
+        events = parse_events([text])
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0]["actor"], "Actor1")
+        self.assertEqual(events[1]["actor"], "Actor2")
+
+
+    def test_crlf_and_blank_lines(self):
+        text = (
+            "2024-06-15 14:10 Actor1: Did something\r\n\r\n"
+            "2024-06-16 09:00 Actor2: Did another"
+        )
+        events = parse_events([text])
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0]["actor"], "Actor1")
+        self.assertEqual(events[1]["actor"], "Actor2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix parsing of blank line and CRLF separated events
- adjust regex whitespace handling
- add regression tests

## Testing
- `python -m unittest tests.test_parse_events -v`