### PR TITLE
Add OCR and HTML parsing to evidence extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ protobuf==6.31.0
 pyvis==0.3.2
 jinja2==3.1.3
 tqdm==4.66.4
+html2text==2024.2.26
+pytesseract==0.3.10
+pillow==10.3.0


### PR DESCRIPTION
## Summary
- use html2text for HTML body conversion
- load junk cleanup regexes from config
- recursively save attachments including images
- OCR image attachments and add text to list
- organize evidence by date and sender
- produce index.json and evidence_summary.csv
- include message header metadata on events
- add new dependencies

## Testing
- `python tests/test_parse_events.py`
- `python -m py_compile claim_irregularity_finder.py`
