### PR TITLE
Limit event back links

### DIFF
--- a/claim_irregularity_finder.py
+++ b/claim_irregularity_finder.py
@@ -246,21 +246,31 @@ def parse_events(texts: List[str]) -> List[Dict]:
                 )
     return events
 
-def build_graph(events: List[Dict]) -> nx.DiGraph:
+def build_graph(events: List[Dict], max_back_links: int = 1) -> nx.DiGraph:
+    """Return a directed graph linking each event to earlier ones.
+
+    Nodes are added for each event in chronological order. By default an event
+    links only to the immediately preceding event. ``max_back_links`` controls
+    how many prior events may connect to the current one. If the event ``details``
+    contain the phrases "in response to" or "following" (case insensitive), the
+    event links to **all** previous events regardless of this limit.
+    """
+
     G = nx.DiGraph()
     for evt in tqdm(events, desc="Adding nodes"):
         G.add_node(evt["id"], **evt)
     for i, evt in enumerate(tqdm(events, desc="Linking events")):
-        ts_i = datetime.fromisoformat(evt["timestamp"])
-        for j in range(i):
-            prev = events[j]
-            ts_j = datetime.fromisoformat(prev["timestamp"])
-            if any(x in evt["details"].lower() for x in ["in response to", "following"]):
-                G.add_edge(prev["id"], evt["id"])
+        details_lower = evt["details"].lower()
+        if "in response to" in details_lower or "following" in details_lower:
+            back_range = range(i)
+        else:
+            if max_back_links is None or max_back_links <= 0:
+                back_range = []
             else:
-                diff_seconds = (ts_i - ts_j).total_seconds()
-                if 0 < diff_seconds <= 86400:
-                    G.add_edge(prev["id"], evt["id"])
+                back_range = range(max(0, i - max_back_links), i)
+        for j in back_range:
+            prev = events[j]
+            G.add_edge(prev["id"], evt["id"])
     return G
 
 def detect_irregularities(events: List[Dict], use_cache: bool = True) -> List[Dict]:

--- a/tests/test_build_graph.py
+++ b/tests/test_build_graph.py
@@ -1,0 +1,67 @@
+import ast
+import textwrap
+import types
+import unittest
+
+
+def load_build_graph():
+    with open("claim_irregularity_finder.py", "r", encoding="utf-8") as f:
+        source = f.read()
+    module = ast.parse(source)
+    code_sections = []
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "build_graph":
+            code_sections.append(
+                textwrap.dedent("".join(source.splitlines(True)[node.lineno - 1: node.end_lineno]))
+            )
+    namespace = {}
+    class DiGraph:
+        def __init__(self):
+            self._edges = []
+            self._nodes = {}
+
+        def add_node(self, node, **attrs):
+            self._nodes[node] = attrs
+
+        def add_edge(self, u, v):
+            self._edges.append((u, v))
+
+        def edges(self):
+            return self._edges
+
+    namespace['nx'] = types.SimpleNamespace(DiGraph=DiGraph)
+    exec(
+        "from datetime import datetime\nfrom typing import List, Dict\n" "def tqdm(x, **k):\n    return x\n" + "\n".join(code_sections),
+        namespace,
+    )
+    return namespace["build_graph"]
+
+
+build_graph = load_build_graph()
+
+
+class BuildGraphTest(unittest.TestCase):
+    def make_events(self):
+        return [
+            {"id": "e1", "timestamp": "2024-06-01T00:00:00", "actor": "A", "action": "a1", "type": "Action", "details": ""},
+            {"id": "e2", "timestamp": "2024-06-02T00:00:00", "actor": "B", "action": "a2", "type": "Action", "details": ""},
+            {"id": "e3", "timestamp": "2024-06-03T00:00:00", "actor": "C", "action": "a3", "type": "Action", "details": ""},
+        ]
+
+    def test_default_links_immediate(self):
+        G = build_graph(self.make_events())
+        self.assertEqual(list(G.edges()), [("e1", "e2"), ("e2", "e3")])
+
+    def test_max_back_links(self):
+        G = build_graph(self.make_events(), max_back_links=2)
+        self.assertEqual(set(G.edges()), {("e1", "e2"), ("e2", "e3"), ("e1", "e3")})
+
+    def test_explicit_reference(self):
+        events = self.make_events()
+        events[2]["details"] = "In response to earlier issues"
+        G = build_graph(events)
+        self.assertEqual(set(G.edges()), {("e1", "e2"), ("e1", "e3"), ("e2", "e3")})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow linking to only recent events unless notes reference earlier ones
- expose `max_back_links` parameter
- cover new behaviour with unit tests

## Testing
- `python -m unittest discover -s tests`