### PR TITLE
Fix missing typing import

### DIFF
--- a/claim_irregularity_finder.py
+++ b/claim_irregularity_finder.py
@@ -7,7 +7,7 @@ import base64
 import hashlib
 import sys
 from datetime import datetime
-from typing import List, Dict
+from typing import List, Dict, Union
 import email
 from email import policy
 from email.parser import BytesParser


### PR DESCRIPTION
## Summary
- include Union in typing imports

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*